### PR TITLE
Add additional arguments for headless mode

### DIFF
--- a/bookp.py
+++ b/bookp.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import re
+import tempfile
 from time import sleep
 
 import requests
@@ -58,6 +59,12 @@ def create_session(email, password, oath, environment, browser_visible=True, pro
     logger.info("Starting browser")
     options = webdriver.ChromeOptions()
     options.add_argument("--window-size=2560,1440")
+    if not browser_visible:
+        temp_dir = tempfile.mkdtemp()
+        options.add_argument(f"--user-data-dir={temp_dir}")
+        options.add_argument("--headless")
+        options.add_argument("--no-sandbox")
+        options.add_argument("--disable-gpu")
     if proxy:
         options.add_argument('--proxy-server=' + proxy)
     browser = webdriver.Chrome(options=options)
@@ -140,7 +147,7 @@ def get_download_url(user_agent, cookies, csrf_token, asin, device_id):
                 'originType':'Purchase'
             }
         }
-    }    
+    }
 
     r = requests.post('https://www.amazon.co.uk/hz/mycd/ajax',
         data={'data':json.dumps(data_json), 'csrfToken':csrf_token},


### PR DESCRIPTION
For me, the script would fail on a headless linux server with the following error:

```
Traceback (most recent call last):
  File "/home/doty/src/BulkKindleUSBDownloader/./bookp.py", line 325, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/doty/src/BulkKindleUSBDownloader/./bookp.py", line 287, in main
    cookies, csrf_token, custid = create_session(
                                  ^^^^^^^^^^^^^^^
  File "/home/doty/src/BulkKindleUSBDownloader/./bookp.py", line 68, in create_session
    browser = webdriver.Chrome(options=options)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/doty/src/BulkKindleUSBDownloader/venv/lib/python3.12/site-packages/selenium/webdriver/chrome/webdriver.py", line 45, in __init__
    super().__init__(
  File "/home/doty/src/BulkKindleUSBDownloader/venv/lib/python3.12/site-packages/selenium/webdriver/chromium/webdriver.py", line 66, in __init__
    super().__init__(command_executor=executor, options=options)
  File "/home/doty/src/BulkKindleUSBDownloader/venv/lib/python3.12/site-packages/selenium/webdriver/remote/webdriver.py", line 250, in __init__
    self.start_session(capabilities)
  File "/home/doty/src/BulkKindleUSBDownloader/venv/lib/python3.12/site-packages/selenium/webdriver/remote/webdriver.py", line 342, in start_session
    response = self.execute(Command.NEW_SESSION, caps)["value"]
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/doty/src/BulkKindleUSBDownloader/venv/lib/python3.12/site-packages/selenium/webdriver/remote/webdriver.py", line 429, in execute
    self.error_handler.check_response(response)
  File "/home/doty/src/BulkKindleUSBDownloader/venv/lib/python3.12/site-packages/selenium/webdriver/remote/errorhandler.py", line 232, in check_response
    raise exception_class(message, screen, stacktrace)
selenium.common.exceptions.SessionNotCreatedException: Message: session not created: probably user data directory is already in use, please specify a unique val
ue for --user-data-dir argument, or don't use --user-data-dir
```

It doesn't make sense (why should I have to make it headless explicitly?), but these switches allowed it to complete successfully.